### PR TITLE
Allow for regex in 'Exclude certain URLs'

### DIFF
--- a/src/SiteCrawler.php
+++ b/src/SiteCrawler.php
@@ -175,7 +175,8 @@ class SiteCrawler extends StaticHTMLOutput {
             foreach ( $exclusions as $exclusion ) {
                 $exclusion = trim( $exclusion );
                 if ( $exclusion != '' ) {
-                    if ( false !== strpos( $this->url, $exclusion ) ) {
+                    $exclusion = str_replace('/', '\/', $exclusion);
+                    if ( preg_match("/$exclusion/", $this->url) ) {
                         Logger::l(
                             'Excluding ' . $this->url .
                             ' because of rule ' . $exclusion


### PR DESCRIPTION
It would be nice if 'Exclude certain URLs' allowed for regex, ie excluding both `/url-with-date-01-01-2021` and `/url-with-date-02-01-2021` with `/url-with-date-(.*)-2021`