### PR TITLE
fix PHP notice for anchors with no href

### DIFF
--- a/src/HTMLProcessor.php
+++ b/src/HTMLProcessor.php
@@ -768,7 +768,7 @@ class HTMLProcessor extends StaticHTMLOutput {
         // early abort invalid links as early as possible
         // to save overhead/potential errors
         // apply to other functions
-        if ( $url[0] === '#' ) {
+        if ( empty( $url ) || $url[0] === '#' ) {
             return;
         }
 


### PR DESCRIPTION
problem fixed
`PHP Notice:  Uninitialized string offset: 0 in wp-content/plugins/static-html-output-plugin/src/HTMLProcessor.php on line 771`